### PR TITLE
Don't bind mount to /sbin (fixes topjohnwu/Magisk#12)

### DIFF
--- a/common/service.sh
+++ b/common/service.sh
@@ -30,12 +30,11 @@ $MODDIR/bin/sepolicy-inject --live
 
 # Expose the root path
 log_print "Mounting supath"
-rm -rf /magisk/.core/bin $MODDIR/sbin_bind
-mkdir -p $MODDIR/sbin_bind 
-/data/busybox/cp -afc /sbin/. $MODDIR/sbin_bind
-chmod 755 $MODDIR/sbin_bind
-ln -s $MODDIR/bin/* $MODDIR/sbin_bind
-mount -o bind $MODDIR/sbin_bind /sbin
+/data/busybox/mount -o remount,rw /
+rm -rf /magisk/.core/bin
+ln -s "$MODDIR"/bin/* /sbin/
+chmod 751 /sbin
+/data/busybox/mount -o remount,ro /
 
 # Run su.d
 for script in $MODDIR/su.d/* ; do


### PR DESCRIPTION
The Note 7 (TW 6.0) and TW 7.0 beta kernels set CONFIG_RKP_NS_PROT=y
which prevents the magisk ext4 image from being mounted without
"nosuid". This poses a problem since /init cannot execute services for
binaries in a noexec-mounted /sbin unless a type_bounds statement is
added to the SELinux policy, which may restrict what the services can
do.

An example is /sbin/adbd. On the TouchWiz versions listed above, /init
can no longer relaunch adbd after the system boots up.

This commit works around the problem by avoiding an /sbin bind mount and
simply symlinking the su binaries to the rootfs /sbin.